### PR TITLE
Drop dependencies for Inkscape 1.0 compatibility

### DIFF
--- a/boxmaker.inx
+++ b/boxmaker.inx
@@ -4,8 +4,6 @@
   <id>eu.twot.render.boxmaker</id>
 
   <dependency type="executable" location="extensions">boxmaker.py</dependency>
-  <dependency type="executable" location="extensions">simpletransform.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>
 
   <param name="unit" _gui-text="Unit" type="optiongroup" appearance="minimal">
     <option value="mm">mm</option>


### PR DESCRIPTION
I think this is the right thing - I certainly had to remove these lines to get it to load in Inkscape 1.0 alpha 2. See http://wiki.inkscape.org/wiki/index.php/Updating_your_Extension_for_1.0 for more info.